### PR TITLE
Support for phantom grammar rules and option to suppress the Set version of local closure

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -47,6 +47,7 @@ options =
     , Option []    ["coq-loadpath"]  (ReqArg CoqLoadPath "DIR") "Coq: directory for LoadPath"
     , Option []    ["coq-ott"]       (ReqArg CoqOtt "LIB")      "Coq: name of library to Require"
     , Option []    ["coq-stdout"]    (NoArg CoqStdout)          "Coq: send output to standard out"
+    , Option []    ["coq-nolcset"]   (NoArg CoqNoLCSet)         "Coq: suppress the Set version of local closure"
     , Option ['?'] ["help"]          (NoArg Help)               "displays usage information"
     ]
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+let pkgs = import <nixpkgs> { };
+in
+  pkgs.haskellPackages.developPackage {
+    root = ./.;
+    modifier = drv:
+      pkgs.haskell.lib.addBuildTools drv (with pkgs.haskellPackages;
+        [ cabal-install
+          haskell-language-server
+        ]);
+  }

--- a/lngen.cabal
+++ b/lngen.cabal
@@ -35,7 +35,7 @@ library
                      , containers
                      , mtl >= 2.2.1
   default-language:    Haskell2010
-  ghc-options:         -Wall -fwarn-incomplete-record-updates
+  ghc-options:         -Wall -fwarn-incomplete-record-updates -Werror
 
 executable lngen
   hs-source-dirs:      app

--- a/src/ASTCheck.hs
+++ b/src/ASTCheck.hs
@@ -39,7 +39,7 @@ getMvRoots mvds = foldM f [] mvds
 getNtRoots :: (MonadError ProgramError m) => [MvRoot] -> [PreRule] -> m [MvRoot]
 getNtRoots mvs rls = foldM f [] rls
     where
-      f acc (Rule pos rs _ _) =
+      f acc (Rule pos _ rs _ _) =
           if not $ null $ intersect rs (acc ++ mvs)
           then abort $ ASTDupRoots pos (intersect rs (acc ++ mvs))
           else return $ nub rs ++ acc
@@ -53,9 +53,9 @@ getNtRoots mvs rls = foldM f [] rls
    whether a symbol is a metavariable or a nonterminal. -}
 
 toRule :: (MonadError ProgramError m) => [MvRoot] -> [NtRoot] -> PreRule -> m Rule
-toRule mvs nts (Rule pos ns n ps) =
+toRule mvs nts (Rule pos hom ns n ps) =
     do { ps' <- mapM toProduction ps
-       ; return $ Rule pos ns n ps'
+       ; return $ Rule pos hom ns n ps'
        }
     where
       toProduction (Production p es flag constr bs) =
@@ -112,9 +112,9 @@ astOfPreAST (PreAST mvds rls substs fvs) =
     where
       formalRules = map deleteMetaprods $ filter isNonformal rls
 
-      isNonformal (Rule _ es _ _) = "terminals" `notElem` es &&
+      isNonformal (Rule _ _ es _ _) = "terminals" `notElem` es &&
                                     "formula"   `notElem` es
 
-      deleteMetaprods (Rule pos es n ps) = Rule pos es n (filter f ps)
+      deleteMetaprods (Rule pos hom es n ps) = Rule pos hom es n (filter f ps)
           where
             f (Production _ _ fs _ _) = null fs

--- a/src/ComputationMonad.hs
+++ b/src/ComputationMonad.hs
@@ -30,6 +30,7 @@ data ProgFlag
     | CoqOtt String      -- ^ Name of the library to @Require@ in generated output.
     | CoqOutput String   -- ^ Destination for output.
     | CoqStdout          -- ^ Send output to standard out.
+    | CoqNoLCSet         -- ^ Suppress the Set version of Local Closure
     | Help               -- ^ Display usage information.
     deriving ( Eq )
 
@@ -140,3 +141,7 @@ reset =
     do { (b, _) <- get
        ; put (b, Map.empty)
        }
+
+{- | Check whether to not generate lc set  -}
+nolcset :: [ProgFlag] -> Bool
+nolcset = elem CoqNoLCSet

--- a/src/CoqLNOutput.hs
+++ b/src/CoqLNOutput.hs
@@ -117,7 +117,6 @@ coqOfAST ott loadpath ast =
     where
       fixSCC (AcyclicSCC n) = [canon n]
       fixSCC (CyclicSCC ns) = nmap canon ns
-
       aa    = analyzeAST ast
       canon = canonRoot aa
       nts   = reverse $ nmap fixSCC $ stronglyConnComp $ ntGraph aa

--- a/src/CoqLNOutputCommon.hs
+++ b/src/CoqLNOutputCommon.hs
@@ -154,6 +154,23 @@ mvType aa mv = getMvDecl aa mv >>= \decl -> return (toName decl)
 ntType :: MonadFail m => ASTAnalysis -> NtRoot -> m Name
 ntType aa nt = getSyntax aa nt >>= \decl -> return (toName decl)
 
+{- | Checks whether the the given nonterminal root is phantom. -}
+isPhantomNtRoot :: MonadFail m => ASTAnalysis -> NtRoot -> m Bool
+isPhantomNtRoot aa nt = isPhantomSyntax <$> getSyntax aa nt
+
+{- | Checks whether the the given nonterminal root is not phantom. -}
+notPhantomNtRoot :: MonadFail m => ASTAnalysis -> NtRoot -> m Bool
+notPhantomNtRoot aa nt = not . isPhantomSyntax <$> getSyntax aa nt
+
+{- | Returns the canonical type for the given nonterminal root that is
+   not marked as phantom. -}
+ntTypeNonPhantom :: MonadFail m => ASTAnalysis -> NtRoot -> m (Maybe Name)
+ntTypeNonPhantom aa nt = getSyntax aa nt >>= getDeclMb
+  where getDeclMb decl
+          | isPhantomSyntax decl = return Nothing
+          | otherwise = return (Just $ toName decl)
+
+
 
 {- ----------------------------------------------------------------------- -}
 {- * Constructing names: Functions -}

--- a/src/CoqLNOutputDefinitions.hs
+++ b/src/CoqLNOutputDefinitions.hs
@@ -488,7 +488,7 @@ processTactics _ =
     do { return $ printf
          "(** Additional hint declarations. *)\n\
          \\n\
-         \#[export] Hint Resolve plus_le_compat : %s.\n\
+         \#[export] Hint Resolve Nat.add_le_mono : %s.\n\
          \\n\
          \(** Redefine some tactics. *)\n\
          \\n\

--- a/src/CoqLNOutputThmSubst.hs
+++ b/src/CoqLNOutputThmSubst.hs
@@ -279,7 +279,7 @@ subst_constr aaa nt1s =
     sequence $ do { nt1             <- nt1s
                   ; nt2             <- filter (canBindOver aaa nt1) (ntRoots aaa)
                   ; mv2             <- mvsOfNt aaa nt2
-                  ; (Syntax _ _ cs) <- [runM [] $ getSyntax aaa nt1]
+                  ; (Syntax _ _ _ cs) <- [runM [] $ getSyntax aaa nt1]
                   ; c               <- [c | c <- cs, hasBindingArg c]
                   ; return $ local $ thm aaa nt1 nt2 mv2 c
                   }

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -102,6 +102,17 @@ nameHom = do { n <- name ; ignoreHoms ; return n }
 
 {- | Consumes a homomorphism from the input stream. -}
 
+ruleHom :: Parser RuleHom
+ruleHom =
+    do { _ <- text "{{" <?> "homomorphism \"{{ ... }}\""
+             ; do { reserved "phantom"
+                  ; _ <- text "}}"
+                  ; return RuleHom {ruleHomPhantom = True}
+                  }
+               <|>
+               mempty <$ anyChar `manyTill` text "}}"
+             }
+
 ignoreHom :: Parser ()
 ignoreHom =
     do { _ <- text "{{" <?> "homomorphism \"{{ ... }}\""
@@ -145,7 +156,6 @@ metavarDecl =
                   }
              }
 
-
 {- ----------------------------------------------------------------------- -}
 {- * Parsing definitions of nonterminals -}
 
@@ -160,9 +170,9 @@ rule =
        ; _ <- text "::"
        ; n <- ruleName
        ; _ <- text "::="
-       ; _ <- many ignoreHom
+       ; hom <- mconcat <$> many ruleHom
        ; prods <- many production
-       ; return $ Rule pos es n prods
+       ; return $ Rule pos hom es n prods
        }
     where
       ruleName =


### PR DESCRIPTION
This PR does two things.

First, it adds support for handling grammars annotated with the phantom hom. For example, one can write the following grammar rule in ott:
```
sort, s :: '' ::=  {{ phantom }}
                   {{ coq sort }}
  | star                          :: M :: Star {{ coq star }}
```
`ott` will omit the definition of `sort` altogether. This PR suppresses the `size_sort` function and prevents `size_sort` from appearing in the size functions of rules that may depend on `sort`. Otherwise, `lngen` would try to generate induction principles for `sort`, which can fail when `sort` is an opaque type.

Second, the patch adds the option `--coq-nolcset` option, which suppresses the `Set` version of the local closure relation from being generated. I've never found a use case for the set variant so I'd like to have the option to opt-out.

I also removed a deprecated usage of the `instantiate` tactic (it does the same thing as `idtac` when used without arguments), replaced the deprecated `plus_le_compat` with `Nat.add_le_mono` for the hintdb.